### PR TITLE
Feature/nbt wand

### DIFF
--- a/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
+++ b/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
@@ -38,6 +38,7 @@ public class BlockRotator extends JavaPlugin {
 
         rotationWandItem = new ItemStack(Material.STICK);
         ItemMeta wandMeta = rotationWandItem.getItemMeta();
+        wandMeta.setDisplayName("Rotation Tool");
         wandMeta.setLore(Arrays.asList(new String[]{"Block Rotator"}));
         wandMeta.getPersistentDataContainer()
                 .set(CONTROL_ITEM_KEY, PersistentDataType.BYTE, (byte)0x1);

--- a/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
+++ b/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
@@ -6,8 +6,17 @@
 package com.colorfulchew.blockrotator;
 
 import com.colorfulchew.blockrotator.listeners.ItemUseListener;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.sql.Array;
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 /**
@@ -15,10 +24,54 @@ import java.util.logging.Logger;
  * @author Aaron
  */
 public class BlockRotator extends JavaPlugin {
-    public Logger log;
+
+    public static Logger log;
+
+    public static NamespacedKey CONTROL_ITEM_KEY;
+
+    public static ItemStack rotationWandItem;
+
+    public ShapedRecipe rotationWand;
 
     @Override
     public void onEnable() {
+        CONTROL_ITEM_KEY = new NamespacedKey(this,"rotator_wand");
+
+        rotationWandItem = new ItemStack(Material.STICK);
+        ItemMeta wandMeta = rotationWandItem.getItemMeta();
+        wandMeta.setLore(Arrays.asList(new String[]{"Block Rotator"}));
+        wandMeta.getPersistentDataContainer()
+                .set(CONTROL_ITEM_KEY, PersistentDataType.BYTE, (byte)0x1);
+        rotationWandItem.setItemMeta(wandMeta);
+
+        rotationWand = new ShapedRecipe(CONTROL_ITEM_KEY, rotationWandItem);
+
+        rotationWand.shape(" g","I ");
+
+        rotationWand.setIngredient('I', Material.STICK);
+
+        RecipeChoice.MaterialChoice allGlazed = new RecipeChoice.MaterialChoice(Arrays.asList(new Material[] {
+                Material.BLACK_GLAZED_TERRACOTTA,
+                Material.BLUE_GLAZED_TERRACOTTA,
+                Material.BROWN_GLAZED_TERRACOTTA,
+                Material.CYAN_GLAZED_TERRACOTTA,
+                Material.GRAY_GLAZED_TERRACOTTA,
+                Material.GREEN_GLAZED_TERRACOTTA,
+                Material.LIGHT_GRAY_GLAZED_TERRACOTTA,
+                Material.LIME_GLAZED_TERRACOTTA,
+                Material.MAGENTA_GLAZED_TERRACOTTA,
+                Material.ORANGE_GLAZED_TERRACOTTA,
+                Material.PINK_GLAZED_TERRACOTTA,
+                Material.PURPLE_GLAZED_TERRACOTTA,
+                Material.RED_GLAZED_TERRACOTTA,
+                Material.WHITE_GLAZED_TERRACOTTA,
+                Material.YELLOW_GLAZED_TERRACOTTA}));
+
+        rotationWand.setIngredient('g', allGlazed);
+        rotationWand.setIngredient(' ', Material.AIR);
+
+        getServer().addRecipe(rotationWand);
+
         log = this.getLogger();
         getServer().getPluginManager().registerEvents(new ItemUseListener(this), this);
 

--- a/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
+++ b/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
@@ -44,21 +44,16 @@ public class BlockRotator extends JavaPlugin {
                 .set(CONTROL_ITEM_KEY, PersistentDataType.BYTE, (byte)0x1);
         rotationWandItem.setItemMeta(wandMeta);
 
-        rotationWand = new ShapedRecipe(CONTROL_ITEM_KEY, rotationWandItem);
-
-        rotationWand.shape(" g","I ");
-
-        rotationWand.setIngredient('I', Material.STICK);
-
         RecipeChoice.MaterialChoice allGlazed = new RecipeChoice.MaterialChoice(Arrays.asList(new Material[] {
                 Material.BLACK_GLAZED_TERRACOTTA,
-                Material.BLUE_GLAZED_TERRACOTTA,
-                Material.BROWN_GLAZED_TERRACOTTA,
-                Material.CYAN_GLAZED_TERRACOTTA,
                 Material.GRAY_GLAZED_TERRACOTTA,
-                Material.GREEN_GLAZED_TERRACOTTA,
                 Material.LIGHT_GRAY_GLAZED_TERRACOTTA,
+                Material.BLUE_GLAZED_TERRACOTTA,
+                Material.LIGHT_BLUE_GLAZED_TERRACOTTA,
+                Material.CYAN_GLAZED_TERRACOTTA,
                 Material.LIME_GLAZED_TERRACOTTA,
+                Material.GREEN_GLAZED_TERRACOTTA,
+                Material.BROWN_GLAZED_TERRACOTTA,
                 Material.MAGENTA_GLAZED_TERRACOTTA,
                 Material.ORANGE_GLAZED_TERRACOTTA,
                 Material.PINK_GLAZED_TERRACOTTA,
@@ -67,6 +62,10 @@ public class BlockRotator extends JavaPlugin {
                 Material.WHITE_GLAZED_TERRACOTTA,
                 Material.YELLOW_GLAZED_TERRACOTTA}));
 
+        rotationWand = new ShapedRecipe(CONTROL_ITEM_KEY, rotationWandItem);
+        rotationWand.shape(" g","I ");
+        
+        rotationWand.setIngredient('I', rotationWandItem.getType());
         rotationWand.setIngredient('g', allGlazed);
         rotationWand.setIngredient(' ', Material.AIR);
 

--- a/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
+++ b/src/main/java/com/colorfulchew/blockrotator/BlockRotator.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.sql.Array;
 import java.util.Arrays;
 import java.util.logging.Logger;
 
@@ -77,5 +76,7 @@ public class BlockRotator extends JavaPlugin {
     }
     
     @Override
-    public void onDisable() {}
+    public void onDisable() {
+        getServer().removeRecipe(CONTROL_ITEM_KEY);
+    }
 }

--- a/src/main/java/com/colorfulchew/blockrotator/listeners/ItemUseListener.java
+++ b/src/main/java/com/colorfulchew/blockrotator/listeners/ItemUseListener.java
@@ -9,6 +9,7 @@ import com.colorfulchew.blockrotator.BlockRotator;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -24,6 +25,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
 
 /**
  *
@@ -36,6 +39,22 @@ public class ItemUseListener implements Listener {
     
     public ItemUseListener(BlockRotator plugin) {
         this.plugin = plugin;
+    }
+
+    private boolean HoldingWand(PlayerInteractEvent event){
+        if (!event.hasItem())
+            return false;
+        ItemStack item = event.getItem();
+        if (item.getType() != Material.STICK)
+            return false;
+        if( item.getItemMeta() == null
+                || item.getItemMeta().getPersistentDataContainer() == null)
+            return false;
+
+        byte isWand = item.getItemMeta().getPersistentDataContainer().getOrDefault(plugin.CONTROL_ITEM_KEY,
+                PersistentDataType.BYTE,
+                (byte)0b0);
+        return isWand == 0x1;
     }
 
     private static boolean PassesBlacklist(Block block){
@@ -113,7 +132,7 @@ public class ItemUseListener implements Listener {
         if (ignoreNext) return;
         // Checks player permissions
         if (e.getPlayer().hasPermission("blockrotator.rotate")) {
-            if (e.getMaterial() == Material.BONE) {
+            if(HoldingWand(e)){
                 if (!canBuild(e)) return;
                 if (e.hasBlock()) {
                     Block block = e.getClickedBlock();


### PR DESCRIPTION
Here's my Proof of Concept for use of NBT data tags instead of a set item, this could be improved to be a configurable item in the future, but it works for now without impacting vanilla item use.
crafting recipe is:
[   ][G]
[ | ][   ]
In which | is a stick and G is any glazed terracotta.

I've also tested this in 1.16.1 with it successfully rotating and flipping all new polished basalt, slab and stair types.